### PR TITLE
Add meeting cost variable

### DIFF
--- a/meeting_cost_calculator/content_scripts/calendar_integration.js
+++ b/meeting_cost_calculator/content_scripts/calendar_integration.js
@@ -1,6 +1,7 @@
 console.log("Meeting Cost Calculator: Content script loaded on Google Calendar.");
 
 let averageCostPerHour = 0; // Default value
+let meetingCost = 0; // attendeeCount * averageCostPerHour
 
 function loadAverageCost() {
   if (chrome.storage && chrome.storage.sync) {
@@ -59,6 +60,9 @@ function processMeetingDetails(eventPopupElement) {
   ;
 
   console.log('Content Script: Extracted Attendee Count (approx) -', attendeeCount);
+
+  meetingCost = attendeeCount * averageCostPerHour;
+  console.log('Content Script: Meeting Cost (per hour) -', meetingCost);
 
   // const durationHours = extractDuration(eventPopupElement); // To be defined in Task 3.3
   // console.log('Content Script: Extracted Duration (hours) -', durationHours);


### PR DESCRIPTION
## Summary
- add `meetingCost` to hold attendeeCost per hour
- calculate meeting cost each time attendee count is extracted

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68436719e584832ea14c5aa979e8cdd1