### PR TITLE
Check existing cost element before processing popup

### DIFF
--- a/meeting_cost_calculator/content_scripts/calendar_integration.js
+++ b/meeting_cost_calculator/content_scripts/calendar_integration.js
@@ -103,7 +103,9 @@ function duplicateGuestInfo(eventPopupElement) {
 function observeCalendarChanges() {
   const targetNode = document.body;
   const config = { childList: true, subtree: true };
-  let costProcessed = false;
+  // Instead of relying on a processed flag, we'll check for our cost
+  // display element by ID to determine if the popup has already been
+  // processed. If it exists, we skip further handling for that popup.
 
   const callback = function(mutationsList, observer) {
     for(const mutation of mutationsList) {
@@ -117,9 +119,12 @@ function observeCalendarChanges() {
           return;
         }
         
-        if (eventPopup[0].innerText && !costProcessed) {
+        if (eventPopup[0].innerText) {
+          // If we already inserted the cost display element, skip processing
+          if (eventPopup[0].querySelector(`#${costDisplayId}`)) {
+            return;
+          }
           console.log('Content Script: Event detail pop-up detected.', eventPopup);
-          costProcessed = true; // Mark as processed to avoid re-processing
           
           // Give GCal a moment to fully render the popup's content before processing
           setTimeout(() => {


### PR DESCRIPTION
## Summary
- check if the cost display element already exists when a calendar popup appears
- avoid duplicating processing based on existence of element instead of a flag

## Testing
- `npm test` *(fails: Could not read package.json)*
- `pytest` *(no tests ran)*

------
https://chatgpt.com/codex/tasks/task_e_6844c1b702b0832e8787669a0b9fb4aa